### PR TITLE
Sync project card status to issues

### DIFF
--- a/.github/workflows/project_card_issue_sync.yml
+++ b/.github/workflows/project_card_issue_sync.yml
@@ -1,0 +1,21 @@
+name: 'Sync project card status to issues'
+
+on:
+  project_card:
+    types: [created, edited, moved]
+
+permissions:
+  repository-projects: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  action:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/issue-states@v2
+        with:
+            github-token: ${{ github.token }}
+            open-issue-columns: 'Work In Progress 🏗, Focus 🫖, Dark Pool 🕳, Backlog 😪'
+            closed-issue-columns: 'Completed 🦾'
+            log-output: false


### PR DESCRIPTION
Closes issue when moved to Completed, re-opens when moved elsewhere.